### PR TITLE
Made FormsMixin compatible with Dougrain v0.5.

### DIFF
--- a/dougrain_forms/mixin.py
+++ b/dougrain_forms/mixin.py
@@ -21,7 +21,7 @@ class FormsMixin(object):
 
         return Form(dict(href=href, **kwargs), self.base_uri)
 
-    @mutator
+    @mutator()
     def set_form(self, rel, target, **kwargs):
         """Adds a form to the document.
 
@@ -59,7 +59,7 @@ class FormsMixin(object):
         # Replace the current form instead of appending it
         forms[rel] = new_form
 
-    @mutator
+    @mutator()
     def delete_form(self, rel=None):
         """Removes a form resource from this document identified by its
         ``rel``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-dougrain==0.4
+dougrain==0.5


### PR DESCRIPTION
FormsMixin.set_form and FormsMixin.delete_form use Dougrain's mutator decorator, which changed its signature in v0.5. mutator is now a function that accepts a list of caches to invalidate as optional arguments and returns the actual decorator.

FormsMixin does not invalidate any caches, so it doesn't really need mutator, but I've kept the decorator in place as an annotation on those methods.
