### PR TITLE
Python 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
 
 install: "pip install -r requirements.txt -r requirements_test.txt --use-mirrors"
 script: python -m pytest

--- a/dougrain_forms/form.py
+++ b/dougrain_forms/form.py
@@ -7,7 +7,10 @@ A forms generation extension for dougrain.
 """
 
 from __future__ import absolute_import, print_function, unicode_literals
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    from urllib import parse as urlparse
 
 
 class Form(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-dougrain==0.5
+dougrain==0.5.1

--- a/setup.py
+++ b/setup.py
@@ -7,14 +7,21 @@ except ImportError:
     from distutils.core import setup, find_packages
 
 
-# Version info -- read without importing
-_locals = {}
-version_module = execfile('dougrain_forms/_version.py', _locals)
-version = _locals['__version__']
+def _xfile(filename):
+    with open(filename) as f:
+        code = compile(f.read(), filename, 'exec')
+        exec(code, global_vars, local_vars)
+
+
+def get_version():
+    # Version info -- read without importing
+    _locals = {}
+    version_module = _xfile('dougrain_forms/_version.py', _locals)
+    return _locals['__version__']
 
 setup(
     name='dougrain-forms',
-    version=version,
+    version=get_version(),
     description='Unofficial hypermedia form extension for dougrain.',
     long_description=open('README.rst').read(),
     author='Pascal Hartig',
@@ -36,6 +43,9 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: POSIX',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Python Modules',
     )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'dougrain_forms'
     ],
     install_requires=[
-        'dougrain==0.4'
+        'dougrain==0.5.1'
     ],
     license='BSD',
     classifiers=(


### PR DESCRIPTION
I recently released dougrain version 0.5.1, which adds compatibility with Python 3.3. This branch updates dougrain-forms to depend on dougrain 0.5.1, incorporates your branch py33, and fixes one remaining ImportError under Python 3.
